### PR TITLE
[BNG-53] 정기연봉조정 > 기준설정 API 구현

### DIFF
--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/controller/AdjustController.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/controller/AdjustController.java
@@ -19,6 +19,7 @@ import com.bongsco.poscosalarybackend.adjust.dto.request.AdjInfoPostRequest;
 import com.bongsco.poscosalarybackend.adjust.dto.request.AdjInfoUpdateRequest;
 import com.bongsco.poscosalarybackend.adjust.dto.response.AdjustResponse;
 import com.bongsco.poscosalarybackend.adjust.service.AdjustService;
+import com.bongsco.poscosalarybackend.global.dto.JsonResult;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,45 +35,45 @@ public class AdjustController {
 
     @Operation(summary = "조정 정보 조회", description = "startYear와 endYear를 통해 조정 정보를 조회합니다.")
     @GetMapping
-    public ResponseEntity<AdjustResponse> getAdjustInfo(
+    public ResponseEntity<JsonResult<AdjustResponse>> getAdjustInfo(
         @RequestParam(value = "startYear", required = false) Long startYear,
         @RequestParam(value = "endYear", required = false) Long endYear) {
 
         AdjustResponse response = adjustService.getAdjustInfo(startYear, endYear);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(JsonResult.success(response));
     }
 
     @Operation(summary = "조정 정보 수정", description = "조정 정보를 수정합니다.")
     @PatchMapping("/{id}")
-    public ResponseEntity<Map<String, String>> updateAdjustInfo(
+    public ResponseEntity<JsonResult<Map<String, String>>> updateAdjustInfo(
         @Valid @PathVariable Long id,
         @RequestBody AdjInfoUpdateRequest updateRequest) {
 
         adjustService.updateAdjustInfo(id, updateRequest);
 
-        return ResponseEntity.ok(Map.of("message", "Successfully changed"));
+        return ResponseEntity.ok(JsonResult.success(Map.of("message", "Successfully changed")));
     }
 
     @Operation(summary = "조정 정보 삭제", description = "조정 정보를 삭제합니다.")
     @DeleteMapping
-    public ResponseEntity<Map<String, String>> deleteAdjustInfo(
+    public ResponseEntity<JsonResult<Map<String, String>>> deleteAdjustInfo(
         @RequestBody AdjInfoDeleteRequest deleteRequest) {
 
         adjustService.deleteAdjustInfo(deleteRequest);
 
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(Map.of("message", "Successfully deleted"));
+            .body(JsonResult.success(Map.of("message", "Successfully deleted")));
     }
 
     @Operation(summary = "조정 정보 추가", description = "조정 정보를 추가합니다.")
     @PostMapping
-    public ResponseEntity<Map<String, String>> postAdjustInfo(
+    public ResponseEntity<JsonResult<Map<String, String>>> postAdjustInfo(
         @Valid @RequestBody AdjInfoPostRequest postRequest) {
 
         adjustService.postAdjustInfo(postRequest);
 
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(Map.of("message", "Successfully post"));
+            .body(JsonResult.success(Map.of("message", "Successfully post")));
     }
 }

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/controller/CriteriaController.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/controller/CriteriaController.java
@@ -75,7 +75,7 @@ public class CriteriaController {
         return ResponseEntity.ok(JsonResult.success(updatedData));
     }
 
-    @DeleteMapping
+    @DeleteMapping("/{adj_info_id}/payband")
     public ResponseEntity<Void> deletePaybandCriteria(
         @Valid @RequestBody PaybandCriteriaDeleteRequest request) {
         criteriaService.deletePaybandCriteria(request);

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/controller/CriteriaController.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/controller/CriteriaController.java
@@ -1,0 +1,84 @@
+package com.bongsco.poscosalarybackend.adjust.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bongsco.poscosalarybackend.adjust.domain.PaybandCriteria;
+import com.bongsco.poscosalarybackend.adjust.domain.RankIncrementRate;
+import com.bongsco.poscosalarybackend.adjust.dto.request.PaybandCriteriaDeleteRequest;
+import com.bongsco.poscosalarybackend.adjust.dto.request.PaybandCriteriaRequest;
+import com.bongsco.poscosalarybackend.adjust.dto.request.RankIncrementRateRequest;
+import com.bongsco.poscosalarybackend.adjust.dto.request.SubjectCriteriaRequest;
+import com.bongsco.poscosalarybackend.adjust.service.CriteriaService;
+import com.bongsco.poscosalarybackend.global.dto.JsonResult;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+@Tag(name = "기준 설정 관련 API", description = "대상자 기준, 기준연봉, 평가차등 등등..")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/criteria")
+public class CriteriaController {
+
+    private final CriteriaService criteriaService;
+
+    @PatchMapping("/{adj_info_id}/subject")
+    public ResponseEntity<JsonResult<SubjectCriteriaRequest>> saveSubjectCriteria(
+        @PathVariable(name = "adj_info_id") Long adjInfoId,
+        @Valid @RequestBody SubjectCriteriaRequest subjectCriteriaRequest
+    ) {
+        subjectCriteriaRequest = criteriaService.addSubjectInfo(adjInfoId, subjectCriteriaRequest);
+        return ResponseEntity.ok(JsonResult.success(subjectCriteriaRequest));
+    }
+
+    @PatchMapping("/{adj_info_id}/increment")
+    public ResponseEntity<JsonResult<RankIncrementRateRequest>> updateRankIncrementRates(
+        @PathVariable(name = "adj_info_id") Long adjInfoId,
+        @Valid @RequestBody RankIncrementRateRequest request) {
+        List<RankIncrementRate> savedData = criteriaService.updateRankIncrementRates(adjInfoId, request);
+        return ResponseEntity.ok(JsonResult.success(request));
+    }
+
+    @PostMapping("/{adj_info_id}/increment")
+    public ResponseEntity<JsonResult<RankIncrementRateRequest>> saveRankIncrementRates(
+        @PathVariable(name = "adj_info_id") Long adjInfoId,
+        @Valid @RequestBody RankIncrementRateRequest request) {
+        List<RankIncrementRate> savedData = criteriaService.saveRankIncrementRates(adjInfoId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(JsonResult.success(request));
+    }
+
+    @PostMapping("/{adj_info_id}/payband")
+    public ResponseEntity<JsonResult<List<PaybandCriteria>>> savePaybandCriteria(
+        @PathVariable(name = "adj_info_id") Long adjInfoId,
+        @Valid @RequestBody PaybandCriteriaRequest request) {
+        List<PaybandCriteria> savedData = criteriaService.savePaybandCriteria(adjInfoId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(JsonResult.success(savedData));
+    }
+
+    @PatchMapping("/{adj_info_id}/payband")
+    public ResponseEntity<JsonResult<List<PaybandCriteria>>> updatePaybandCriteria(
+        @PathVariable(name = "adj_info_id") Long adjInfoId,
+        @Valid @RequestBody PaybandCriteriaRequest request) {
+        List<PaybandCriteria> updatedData = criteriaService.updatePaybandCriteria(adjInfoId, request);
+        return ResponseEntity.ok(JsonResult.success(updatedData));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deletePaybandCriteria(
+        @Valid @RequestBody PaybandCriteriaDeleteRequest request) {
+        criteriaService.deletePaybandCriteria(request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/domain/PaybandCriteria.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/domain/PaybandCriteria.java
@@ -5,13 +5,10 @@ import java.math.BigDecimal;
 import org.hibernate.annotations.SQLDelete;
 
 import com.bongsco.poscosalarybackend.global.domain.BaseEntity;
-import com.bongsco.poscosalarybackend.global.domain.Status;
 import com.bongsco.poscosalarybackend.user.domain.Grade;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "payband_criteria")
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE payband_criteria SET deleted = true WHERE id = ?")
@@ -43,9 +40,6 @@ public class PaybandCriteria extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "grade_id", nullable = false)
     private Grade grade;
-
-    @Enumerated(EnumType.STRING)
-    private Status status;
 
     @Column(precision = 20, scale = 2)
     private BigDecimal upperLimitPrice;

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/domain/RankIncrementRate.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/domain/RankIncrementRate.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "rank_increment_rate")
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE rank_increment_rate SET deleted = true WHERE rank_id = ? AND adj_info_id = ? AND grade_id = ?ß")

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/dto/request/PaybandCriteriaDeleteRequest.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/dto/request/PaybandCriteriaDeleteRequest.java
@@ -1,0 +1,20 @@
+package com.bongsco.poscosalarybackend.adjust.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaybandCriteriaDeleteRequest {
+    @NotEmpty
+    private List<Long> paybandIds;
+}
+

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/dto/request/PaybandCriteriaRequest.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/dto/request/PaybandCriteriaRequest.java
@@ -1,0 +1,31 @@
+package com.bongsco.poscosalarybackend.adjust.dto.request;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PaybandCriteriaRequest {
+
+    @NotNull
+    private Map<Long, PaybandCriteriaDetail> gradeData;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class PaybandCriteriaDetail {
+        private BigDecimal upperLimitPrice;
+        private BigDecimal lowerLimitPrice;
+    }
+}
+

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/dto/request/RankIncrementRateRequest.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/dto/request/RankIncrementRateRequest.java
@@ -1,0 +1,38 @@
+package com.bongsco.poscosalarybackend.adjust.dto.request;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RankIncrementRateRequest {
+    @NotNull
+    private Map<Long, Map<Long, RankIncrementRateDetail>> rankData;
+
+    @NotNull
+    private BigDecimal evalDiffBonusPromoted;
+
+    @NotNull
+    private BigDecimal evalDiffIncrementPromoted;
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    public static class RankIncrementRateDetail {
+        private BigDecimal evalDiffBonus;
+        private BigDecimal evalDiffIncrement;
+    }
+}
+
+
+
+

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/dto/request/SubjectCriteriaRequest.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/dto/request/SubjectCriteriaRequest.java
@@ -1,0 +1,32 @@
+package com.bongsco.poscosalarybackend.adjust.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SubjectCriteriaRequest {
+
+    @NotNull
+    private LocalDate baseDate;
+
+    @NotNull
+    private LocalDate exceptionStartDate;
+
+    @NotNull
+    private LocalDate exceptionEndDate;
+
+    @NotNull
+    private List<Long> gradeIds;
+
+    @NotNull
+    private List<Long> paymentCriteriaIds;
+}

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/GradeAdjInfoRepository.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/GradeAdjInfoRepository.java
@@ -1,0 +1,9 @@
+package com.bongsco.poscosalarybackend.adjust.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bongsco.poscosalarybackend.adjust.domain.AdjInfo;
+import com.bongsco.poscosalarybackend.adjust.domain.GradeAdjInfo;
+public interface GradeAdjInfoRepository extends JpaRepository<GradeAdjInfo, Long> {
+    void deleteAllByAdjInfo(AdjInfo adjInfo);
+}

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/GradeRepository.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/GradeRepository.java
@@ -1,0 +1,10 @@
+package com.bongsco.poscosalarybackend.adjust.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bongsco.poscosalarybackend.user.domain.Grade;
+public interface GradeRepository extends JpaRepository<Grade, Long> {
+    List<Grade> findByIdIn(List<Long> gradeIds);
+}

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/PaybandCriteriaRepository.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/PaybandCriteriaRepository.java
@@ -1,6 +1,7 @@
 package com.bongsco.poscosalarybackend.adjust.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,5 +12,7 @@ import com.bongsco.poscosalarybackend.adjust.domain.PaybandCriteria;
 public interface PaybandCriteriaRepository extends JpaRepository<PaybandCriteria, Long> {
     public List<PaybandCriteria> findByAdjInfo_Id(Long id);
 
-    public PaybandCriteria findByAdjInfo_IdAndGrade_Id(Long id, Long gradeId);
+    public Optional<PaybandCriteria> findByAdjInfo_IdAndGrade_Id(Long adjInfoId, Long gradeId);
+
+    void deleteByIdIn(List<Long> paybandIds);
 }

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/PaymentAdjInfoRepository.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/PaymentAdjInfoRepository.java
@@ -1,0 +1,9 @@
+package com.bongsco.poscosalarybackend.adjust.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bongsco.poscosalarybackend.adjust.domain.AdjInfo;
+import com.bongsco.poscosalarybackend.adjust.domain.PaymentAdjInfo;
+public interface PaymentAdjInfoRepository extends JpaRepository<PaymentAdjInfo, Long> {
+    void deleteAllByAdjInfo(AdjInfo adjInfo);
+}

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/PaymentCriteriaRepository.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/PaymentCriteriaRepository.java
@@ -1,0 +1,11 @@
+package com.bongsco.poscosalarybackend.adjust.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bongsco.poscosalarybackend.adjust.domain.PaymentCriteria;
+public interface PaymentCriteriaRepository extends JpaRepository<PaymentCriteria, Long> {
+
+    List<PaymentCriteria> findByIdIn(List<Long> paymentCriteriaIds);
+}

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/RankIncrementRateRepository.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/RankIncrementRateRepository.java
@@ -1,5 +1,7 @@
 package com.bongsco.poscosalarybackend.adjust.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +9,5 @@ import com.bongsco.poscosalarybackend.adjust.domain.RankIncrementRate;
 
 @Repository
 public interface RankIncrementRateRepository extends JpaRepository<RankIncrementRate, Long> {
-    RankIncrementRate findByRankIdAndAdjInfoIdAndGradeId(Long rankId, Long adjInfoId, Long gradeId);
+    Optional<RankIncrementRate> findByRankIdAndAdjInfoIdAndGradeId(Long rankId, Long adjInfoId, Long gradeId);
 }

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/RankRepository.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/repository/RankRepository.java
@@ -1,0 +1,7 @@
+package com.bongsco.poscosalarybackend.adjust.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bongsco.poscosalarybackend.user.domain.Rank;
+public interface RankRepository extends JpaRepository<Rank, Long> {
+}

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/service/AdjSubjectService.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/service/AdjSubjectService.java
@@ -66,7 +66,7 @@ public class AdjSubjectService {
                     .toBuilder()
                     .subjectUse(changedSubjectUseEmployee.getSubjectUse())
                     .build();
-                adjSubjectRepository.save(adjSubject);
+                adjSubjectRepository.save(saveAdjSubject);
             });
     }
 
@@ -98,7 +98,7 @@ public class AdjSubjectService {
             adjSubject.getEmployee().getRank().getId(),
             adjSubject.getAdjInfo().getId(),
             adjSubject.getEmployee().getGrade().getId()
-        );
+        ).orElseThrow(() -> new CustomException(RESOURCE_NOT_FOUND));
 
         if (rankIncrementRate != null) {
             response.setEvalDiffIncrement(rankIncrementRate.getEvalDiffIncrement());
@@ -149,7 +149,7 @@ public class AdjSubjectService {
                     changedEmployee.getEmployeeId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
             AdjSubject saveAdjSubject = adjSubject.toBuilder().subjectUse(changedEmployee.getSubjectUse()).build();
-            adjSubjectRepository.save(adjSubject);
+            adjSubjectRepository.save(saveAdjSubject);
         });
     }
 

--- a/src/main/java/com/bongsco/poscosalarybackend/adjust/service/CriteriaService.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/adjust/service/CriteriaService.java
@@ -1,0 +1,241 @@
+package com.bongsco.poscosalarybackend.adjust.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bongsco.poscosalarybackend.adjust.domain.AdjInfo;
+import com.bongsco.poscosalarybackend.adjust.domain.GradeAdjInfo;
+import com.bongsco.poscosalarybackend.adjust.domain.PaybandCriteria;
+import com.bongsco.poscosalarybackend.adjust.domain.PaymentAdjInfo;
+import com.bongsco.poscosalarybackend.adjust.domain.PaymentCriteria;
+import com.bongsco.poscosalarybackend.adjust.domain.RankIncrementRate;
+import com.bongsco.poscosalarybackend.adjust.dto.request.PaybandCriteriaDeleteRequest;
+import com.bongsco.poscosalarybackend.adjust.dto.request.PaybandCriteriaRequest;
+import com.bongsco.poscosalarybackend.adjust.dto.request.RankIncrementRateRequest;
+import com.bongsco.poscosalarybackend.adjust.dto.request.SubjectCriteriaRequest;
+import com.bongsco.poscosalarybackend.adjust.repository.AdjustRepository;
+import com.bongsco.poscosalarybackend.adjust.repository.GradeAdjInfoRepository;
+import com.bongsco.poscosalarybackend.adjust.repository.GradeRepository;
+import com.bongsco.poscosalarybackend.adjust.repository.PaybandCriteriaRepository;
+import com.bongsco.poscosalarybackend.adjust.repository.PaymentAdjInfoRepository;
+import com.bongsco.poscosalarybackend.adjust.repository.PaymentCriteriaRepository;
+import com.bongsco.poscosalarybackend.adjust.repository.RankIncrementRateRepository;
+import com.bongsco.poscosalarybackend.adjust.repository.RankRepository;
+import com.bongsco.poscosalarybackend.global.exception.CustomException;
+import com.bongsco.poscosalarybackend.global.exception.ErrorCode;
+import com.bongsco.poscosalarybackend.user.domain.Grade;
+import com.bongsco.poscosalarybackend.user.domain.Rank;
+
+import lombok.RequiredArgsConstructor;
+@Service
+@RequiredArgsConstructor
+public class CriteriaService {
+
+    private final AdjustRepository adjustRepository;
+    private final GradeAdjInfoRepository gradeAdjInfoRepository;
+    private final PaymentAdjInfoRepository paymentAdjInfoRepository;
+    private final PaymentCriteriaRepository paymentCriteriaRepository;
+    private final GradeRepository gradeRepository;
+    private final RankRepository rankRepository;
+    private final RankIncrementRateRepository rankIncrementRateRepository;
+    private final PaybandCriteriaRepository paybandCriteriaRepository;
+
+    @Transactional
+    public SubjectCriteriaRequest addSubjectInfo(Long adjInfoId, SubjectCriteriaRequest request) {
+        AdjInfo existingAdjInfo = adjustRepository.findById(adjInfoId)
+            .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        // 기존 데이터 업데이트 (toBuilder 사용)
+        AdjInfo updatedAdjInfo = existingAdjInfo.toBuilder()
+            .baseDate(request.getBaseDate() != null ? request.getBaseDate() : existingAdjInfo.getBaseDate())
+            .exceptionStartDate(request.getExceptionStartDate() != null ? request.getExceptionStartDate() :
+                existingAdjInfo.getExceptionStartDate())
+            .exceptionEndDate(request.getExceptionEndDate() != null ? request.getExceptionEndDate() :
+                existingAdjInfo.getExceptionEndDate())
+            .build();
+
+        adjustRepository.save(updatedAdjInfo);
+
+        // 기존 GradeAdjInfo 및 PaymentAdjInfo 삭제 후 갱신
+        if (request.getGradeIds() != null) {
+            gradeAdjInfoRepository.deleteAllByAdjInfo(existingAdjInfo);
+            List<Grade> grades = gradeRepository.findByIdIn(request.getGradeIds());
+            List<GradeAdjInfo> gradeAdjInfos = grades.stream()
+                .map(grade -> new GradeAdjInfo(null, grade, updatedAdjInfo))
+                .collect(Collectors.toList());
+            gradeAdjInfoRepository.saveAll(gradeAdjInfos);
+        }
+
+        if (request.getPaymentCriteriaIds() != null) {
+            paymentAdjInfoRepository.deleteAllByAdjInfo(existingAdjInfo);
+            List<PaymentCriteria> paymentCriteria = paymentCriteriaRepository.findByIdIn(
+                request.getPaymentCriteriaIds());
+            List<PaymentAdjInfo> paymentAdjInfos = paymentCriteria.stream()
+                .map(payment -> new PaymentAdjInfo(null, payment, updatedAdjInfo))
+                .collect(Collectors.toList());
+            paymentAdjInfoRepository.saveAll(paymentAdjInfos);
+        }
+
+        return request;
+    }
+
+    @Transactional
+    public List<RankIncrementRate> saveRankIncrementRates(Long adjInfoId, RankIncrementRateRequest request) {
+
+        AdjInfo existingAdjInfo = adjustRepository.findById(adjInfoId)
+            .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        AdjInfo updatedAdjInfo = existingAdjInfo.toBuilder()
+            .evalAnnualSalaryIncrement(request.getEvalDiffIncrementPromoted())
+            .evalPerformProvideRate(request.getEvalDiffBonusPromoted())
+            .build();
+
+        // 모든 rank_id -> grade_id -> 상세 정보 매핑
+        List<RankIncrementRate> rankIncrementRates = request.getRankData().entrySet().stream()
+            .flatMap(rankEntry -> {
+                Long rankId = rankEntry.getKey();
+                Rank rank = rankRepository.findById(rankId)
+                    .orElseThrow(() -> new IllegalArgumentException("Rank not found with ID: " + rankId));
+
+                return rankEntry.getValue().entrySet().stream().map(gradeEntry -> {
+                    Long gradeId = gradeEntry.getKey();
+                    Grade grade = gradeRepository.findById(gradeId)
+                        .orElseThrow(() -> new IllegalArgumentException("Grade not found with ID: " + gradeId));
+
+                    return RankIncrementRate.builder()
+                        .adjInfo(updatedAdjInfo)
+                        .rank(rank)
+                        .grade(grade)
+                        .evalDiffBonus(gradeEntry.getValue().getEvalDiffBonus())
+                        .evalDiffIncrement(gradeEntry.getValue().getEvalDiffIncrement())
+                        .build();
+                });
+            })
+            .collect(Collectors.toList());
+
+        return rankIncrementRateRepository.saveAll(rankIncrementRates);
+    }
+
+    @Transactional
+    public List<RankIncrementRate> updateRankIncrementRates(Long adjInfoId, RankIncrementRateRequest request) {
+        AdjInfo existingAdjInfo = adjustRepository.findById(adjInfoId)
+            .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        AdjInfo updatedAdjInfo = existingAdjInfo.toBuilder()
+            .evalAnnualSalaryIncrement(request.getEvalDiffIncrementPromoted())
+            .evalPerformProvideRate(request.getEvalDiffBonusPromoted())
+            .build();
+
+        List<RankIncrementRate> updatedRankIncrementRates = request.getRankData().entrySet().stream()
+            .flatMap(rankEntry -> {
+                Long rankId = rankEntry.getKey();
+                Rank rank = rankRepository.findById(rankId)
+                    .orElseThrow(() -> new IllegalArgumentException("Rank not found with ID: " + rankId));
+
+                return rankEntry.getValue().entrySet().stream().map(gradeEntry -> {
+                    Long gradeId = gradeEntry.getKey();
+                    Grade grade = gradeRepository.findById(gradeId)
+                        .orElseThrow(() -> new IllegalArgumentException("Grade not found with ID: " + gradeId));
+
+                    RankIncrementRateRequest.RankIncrementRateDetail detail = gradeEntry.getValue();
+
+                    // 기존 데이터 존재 여부 확인
+                    Optional<RankIncrementRate> existingRecord =
+                        rankIncrementRateRepository.findByRankIdAndAdjInfoIdAndGradeId(rankId, adjInfoId, gradeId);
+
+                    if (existingRecord.isPresent()) {
+                        // 기존 데이터 업데이트
+                        RankIncrementRate existingRate = existingRecord.get();
+                        existingRate = existingRate.toBuilder()
+                            .evalDiffBonus(detail.getEvalDiffBonus())
+                            .evalDiffIncrement(detail.getEvalDiffIncrement())
+                            .build();
+                        return existingRate;
+                    } else {
+                        // 새로운 데이터 생성
+                        return RankIncrementRate.builder()
+                            .adjInfo(updatedAdjInfo)
+                            .rank(rank)
+                            .grade(grade)
+                            .evalDiffBonus(detail.getEvalDiffBonus())
+                            .evalDiffIncrement(detail.getEvalDiffIncrement())
+                            .build();
+                    }
+                });
+            })
+            .collect(Collectors.toList());
+
+        return rankIncrementRateRepository.saveAll(updatedRankIncrementRates);
+    }
+
+    @Transactional
+    public List<PaybandCriteria> savePaybandCriteria(Long adjInfoId, PaybandCriteriaRequest request) {
+        AdjInfo adjInfo = adjustRepository.findById(adjInfoId)
+            .orElseThrow(() -> new IllegalArgumentException("AdjInfo not found with ID: " + adjInfoId));
+
+        List<PaybandCriteria> paybandCriteriaList = request.getGradeData().entrySet().stream()
+            .map(entry -> {
+                Long gradeId = entry.getKey();
+                Grade grade = gradeRepository.findById(gradeId)
+                    .orElseThrow(() -> new IllegalArgumentException("Grade not found with ID: " + gradeId));
+
+                PaybandCriteriaRequest.PaybandCriteriaDetail detail = entry.getValue();
+
+                return PaybandCriteria.builder()
+                    .adjInfo(adjInfo)
+                    .grade(grade)
+                    .upperLimitPrice(detail.getUpperLimitPrice())
+                    .lowerLimitPrice(detail.getLowerLimitPrice())
+                    .build();
+            })
+            .collect(Collectors.toList());
+
+        return paybandCriteriaRepository.saveAll(paybandCriteriaList);
+    }
+
+    @Transactional
+    public List<PaybandCriteria> updatePaybandCriteria(Long adjInfoId, PaybandCriteriaRequest request) {
+        AdjInfo adjInfo = adjustRepository.findById(adjInfoId)
+            .orElseThrow(() -> new IllegalArgumentException("AdjInfo not found with ID: " + adjInfoId));
+
+        List<PaybandCriteria> updatedPaybandCriteriaList = request.getGradeData().entrySet().stream()
+            .map(entry -> {
+                Long gradeId = entry.getKey();
+                Grade grade = gradeRepository.findById(gradeId)
+                    .orElseThrow(() -> new IllegalArgumentException("Grade not found with ID: " + gradeId));
+
+                PaybandCriteriaRequest.PaybandCriteriaDetail detail = entry.getValue();
+
+                Optional<PaybandCriteria> existingRecord =
+                    paybandCriteriaRepository.findByAdjInfo_IdAndGrade_Id(adjInfoId, gradeId);
+
+                if (existingRecord.isPresent()) {
+                    PaybandCriteria existingCriteria = existingRecord.get();
+                    existingCriteria = existingCriteria.toBuilder()
+                        .upperLimitPrice(detail.getUpperLimitPrice())
+                        .lowerLimitPrice(detail.getLowerLimitPrice())
+                        .build();
+                    return existingCriteria;
+                } else {
+                    return PaybandCriteria.builder()
+                        .adjInfo(adjInfo)
+                        .grade(grade)
+                        .upperLimitPrice(detail.getUpperLimitPrice())
+                        .lowerLimitPrice(detail.getLowerLimitPrice())
+                        .build();
+                }
+            })
+            .collect(Collectors.toList());
+
+        return paybandCriteriaRepository.saveAll(updatedPaybandCriteriaList);
+    }
+
+    @Transactional
+    public void deletePaybandCriteria(PaybandCriteriaDeleteRequest request) {
+        paybandCriteriaRepository.deleteByIdIn(request.getPaybandIds());
+    }
+}

--- a/src/main/java/com/bongsco/poscosalarybackend/global/config/JpaConfig.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/global/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.bongsco.poscosalarybackend.config;
+package com.bongsco.poscosalarybackend.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/bongsco/poscosalarybackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/bongsco/poscosalarybackend/global/exception/ErrorCode.java
@@ -1,34 +1,36 @@
 package com.bongsco.poscosalarybackend.global.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import static org.springframework.http.HttpStatus.*;
+
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
     /* 400 BAD_REQUEST : 잘못된 요청 */
-    INVALID_REFRESH_TOKEN(BAD_REQUEST,"", "리프레시 토큰이 유효하지 않습니다"),
-    MISMATCH_REFRESH_TOKEN(BAD_REQUEST,"", "리프레시 토큰의 유저 정보가 일치하지 않습니다"),
-    CANNOT_NULL_INPUT(BAD_REQUEST,"","NULL값은 입력할 수 없습니다"),
+    INVALID_REFRESH_TOKEN(BAD_REQUEST, "", "리프레시 토큰이 유효하지 않습니다"),
+    MISMATCH_REFRESH_TOKEN(BAD_REQUEST, "", "리프레시 토큰의 유저 정보가 일치하지 않습니다"),
+    CANNOT_NULL_INPUT(BAD_REQUEST, "", "NULL값은 입력할 수 없습니다"),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
-    INVALID_AUTH_TOKEN(UNAUTHORIZED, "","권한 정보가 없는 토큰입니다"),
-    UNAUTHORIZED_MEMBER(UNAUTHORIZED, "","현재 내 계정 정보가 존재하지 않습니다"),
+    INVALID_AUTH_TOKEN(UNAUTHORIZED, "", "권한 정보가 없는 토큰입니다"),
+    UNAUTHORIZED_MEMBER(UNAUTHORIZED, "", "현재 내 계정 정보가 존재하지 않습니다"),
 
     /* 403 FORBIDDEN : 접근 권한 없음 */
-    ACCESS_DENIED(FORBIDDEN,"", "접근이 거부되었습니다"),
-    INVALID_PERMISSION(FORBIDDEN,"", "유효하지 않은 권한입니다"),
+    ACCESS_DENIED(FORBIDDEN, "", "접근이 거부되었습니다"),
+    INVALID_PERMISSION(FORBIDDEN, "", "유효하지 않은 권한입니다"),
 
     /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */
-    USER_NOT_FOUND(NOT_FOUND,"", "해당 유저 정보를 찾을 수 없습니다"),
-    REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "","로그아웃 된 사용자입니다"),
+    USER_NOT_FOUND(NOT_FOUND, "", "해당 유저 정보를 찾을 수 없습니다"),
+    RESOURCE_NOT_FOUND(NOT_FOUND, "", "해당 정보를 찾을 수 없습니다"),
+    REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "", "로그아웃 된 사용자입니다"),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
-    DUPLICATE_RESOURCE(CONFLICT, "","데이터가 이미 존재합니다"),
-    ALREADY_COMPLETED(CONFLICT,"","이미 완료된 단계입니다");
+    DUPLICATE_RESOURCE(CONFLICT, "", "데이터가 이미 존재합니다"),
+    ALREADY_COMPLETED(CONFLICT, "", "이미 완료된 단계입니다");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## ✅ 작업 내용
- [ ] 정기연봉조정 기준설정  API 구현
- [ ] 
## 🤔 중점적으로 봐야 할 부분
- 일단 없습니다..!

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/3d17173d-6810-41a8-811b-c06795817317)

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
- Resolved: #27 

## 🚀 기타 사항

- 추후에 baseup 및 승진자연봉조정에 대한 기준 설정 API도 구현할 예정입니다.